### PR TITLE
Add data source example to the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,18 +22,70 @@ var React = require('react-native');
 var InvertibleScrollView = require('react-native-invertible-scroll-view');
 var {
   ListView,
+  Text,
+  TouchableHighlight,
+  View,
+  StyleSheet,
 } = React;
 
-// Inside of a component's render() method:
-render() {
-  return (
-    <ListView
-      renderScrollComponent={props => <InvertibleScrollView {...props} inverted />}
-      dataSource={...}
-      renderRow={...}
-    />
-  );
+class InvertedScrollComponent extends React.Component {
+  constructor(props) {
+    super(props);
+    this._data = [];
+    this.state = {
+      dataSource: new ListView.DataSource({
+        rowHasChanged: (r1, r2) => r1 !== r2,
+      })
+    };
+  }
+
+  onPress() {
+    this._data.push(`${new Date}`);
+    var rows = this._data;
+    // It's important to keep row ID's consistent to avoid extra renders
+    // But the ID's need to be "reversed" so that the inversion will order the rows correctly
+    var rowIds = this._data.map((row, index) => index).reverse();
+    this.setState({
+      dataSource: this.state.dataSource.cloneWithRows(rows, rowIds)
+    });
+  }
+
+  renderRow(row) {
+    return <Text style={{paddingVertical: 5}}>{row}</Text>
+  }
+
+  render() {
+    return (
+      <View style={styles.container}>
+        <TouchableHighlight onPress={this.onPress.bind(this)} style={styles.button}>
+          <Text>Add a row</Text>
+        </TouchableHighlight>
+        <ListView
+          renderScrollComponent={props => <InvertibleScrollView {...props} inverted />}
+          dataSource={this.state.dataSource}
+          renderRow={this.renderRow.bind(this)}
+        />
+      </View>
+    );
+  }
 }
+
+var styles = StyleSheet.create({
+  button: {
+    marginBottom: 50,
+    borderStyle: 'solid',
+    borderWidth: 1,
+    borderColor: 'black',
+    padding: 10,
+  },
+  container: {
+    paddingTop: 50,
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+    backgroundColor: '#F5FCFF',
+  },
+});
 ```
 
 **NOTE:** When inverting a ListView, you must create a ListView that delegates to an InvertibleScrollView as shown above and not the other way around. Otherwise it will not be able to invert the rows and the content will look upside down. This is true for any scroll view that adds its own children, not just ListView.


### PR DESCRIPTION
I went through a bunch of confusing debugging trying to figure out why I was getting lots of re-renders in my app. It turned out that because I was simply reversing an array to use in an inverted list view's data source, all of the rows were considered to be changed every time data was added (because their indices had changed).

Not sure this is the perfect example, but I think something like it in the readme could save some debugging headaches.
