### PR TITLE
Use scale instead of matrix transforms

### DIFF
--- a/InvertibleScrollView.js
+++ b/InvertibleScrollView.js
@@ -69,19 +69,13 @@ let InvertibleScrollView = React.createClass({
 
 let styles = StyleSheet.create({
   verticallyInverted: {
-    transformMatrix: [
-       1,  0,  0,  0,
-       0, -1,  0,  0,
-       0,  0,  1,  0,
-       0,  0,  0,  1,
+    transform: [
+      { scaleY: -1 },
     ],
   },
   horizontallyInverted: {
-    transformMatrix: [
-      -1,  0,  0,  0,
-       0,  1,  0,  0,
-       0,  0,  1,  0,
-       0,  0,  0,  1,
+    transform: [
+      { scaleX: -1 },
     ],
   },
 });

--- a/README.md
+++ b/README.md
@@ -50,4 +50,4 @@ render() {
 
 ## Implementation
 
-InvertibleScrollView uses transformation matrices to efficiently invert the view. The scroll view's viewport is inverted to flip the entire component, and then each child is inverted again so that the content appears unflipped.
+InvertibleScrollView uses scale transformation to efficiently invert the view. The scroll view's viewport is inverted to flip the entire component, and then each child is inverted again so that the content appears unflipped.


### PR DESCRIPTION
https://github.com/exponentjs/react-native-scrollable-mixin/issues/1
