### PR TITLE
Don't set the _scrollComponent if it is undefined or null

### DIFF
--- a/InvertibleScrollView.js
+++ b/InvertibleScrollView.js
@@ -57,7 +57,7 @@ let InvertibleScrollView = React.createClass({
     }
 
     return cloneReferencedElement(renderScrollComponent(props), {
-      ref: component => { this._scrollComponent = component; },
+      ref: component => { if (component) this._scrollComponent = component; },
     });
   },
 


### PR DESCRIPTION
This fixes the crash with `Unhandled JS Exception: null is not an object (evaluating 'this._scrollComponent.getScrollResponder')`