### PR TITLE
perspective-fix

### DIFF
--- a/InvertibleScrollView.js
+++ b/InvertibleScrollView.js
@@ -7,6 +7,7 @@ import {
   ScrollView,
   StyleSheet,
   View,
+  Platform,
 } from 'react-native';
 import ScrollableMixin from 'react-native-scrollable-mixin';
 
@@ -68,18 +69,31 @@ let InvertibleScrollView = React.createClass({
   },
 });
 
+const verticalTransform = [
+  { scaleY: -1 },
+];
+
+const horizontalTransform = [
+  { scaleX: -1 },
+];
+
+if (Platform.OS === 'android') {
+  verticalTransform.push({
+    perspective: 1280,
+  });
+  horizontalTransform.push({
+    perspective: 1280,
+  })
+}
+
 let styles = StyleSheet.create({
   verticallyInverted: {
     flex: 1,
-    transform: [
-      { scaleY: -1 },
-    ],
+    transform: verticalTransform,
   },
   horizontallyInverted: {
     flex: 1,
-    transform: [
-      { scaleX: -1 },
-    ],
+    transform: horizontalTransform,
   },
 });
 


### PR DESCRIPTION
This is a temporary fix until https://github.com/facebook/react-native/pull/14646 lands.

The invertible scroll view does not work on Android 7.0.0 because of scaleY/scaleX not working without a perspective transform. This fix adds the perspective transform, only on Android. More details at the link.