### PR TITLE
Fix exporting for web

### DIFF
--- a/InvertibleScrollView.js
+++ b/InvertibleScrollView.js
@@ -82,4 +82,4 @@ let styles = StyleSheet.create({
   },
 });
 
-module.exports = InvertibleScrollView;
+export default InvertibleScrollView;


### PR DESCRIPTION
It doesn't work on web otherwise. `Uncaught TypeError: Cannot assign to read only property 'exports' of object '#<Object>'`